### PR TITLE
作業場所編集時に画像が削除できない #6 対応

### DIFF
--- a/src/resources/js/pages/Workplace/Edit.vue
+++ b/src/resources/js/pages/Workplace/Edit.vue
@@ -91,7 +91,7 @@
                     <i class="fa-solid fa-plus mr-2"></i>追加
                   </label>
                 </div>
-                <div v-if="workplace.workplace_images" class="relative w-72 h-[216px] bg-gray-800 rounded-lg">
+                <div v-if="workplace.workplace_images && workplace.workplace_images.length > 0" class="relative w-72 h-[216px] bg-gray-800 rounded-lg">
                   <div @click="deleteRegisteredImage" class="absolute right-0 w-7 h-7  bg-gray-500 text-white rounded-tr-md text-center cursor-pointer">
                     <i class="fa-solid fa-xmark leading-7"></i>
                   </div>


### PR DESCRIPTION
以下の操作で画像が削除できるように修正。

①「作業場所登録」時に画像を「追加」して登録する。
②「作業場所編集」時に①で登録した画像を「×」で削除。