### PR TITLE
「担当者」が空の「作業」が登録できてしまう #8 対応

### DIFF
--- a/src/app/Http/Requests/TaskAssignRequest.php
+++ b/src/app/Http/Requests/TaskAssignRequest.php
@@ -27,7 +27,7 @@ class TaskAssignRequest extends FormRequest
     {
         return [
             'workplace_id' => ['required', 'integer', 'exists:workplaces,id'],
-            'employee_ids' => ['array'],
+            'employee_ids' => ['required', 'array', 'min:1'],
             'employee_ids.*' => ['required', 'integer', 'exists:employees,id'],
             'implementation_date' => ['required', 'string', 'date_format:Y-m-d', 'after_or_equal:today',
                 new WorkplaceAndImplementationDateChecker($this->id, $this->workplace_id, $this->implementation_date),

--- a/src/resources/js/components/Employee.vue
+++ b/src/resources/js/components/Employee.vue
@@ -46,7 +46,7 @@ export default {
         if(registrationId === e.target.value || e.target.value === '') return true
       })
 
-      if (!isDuplication) {
+      if (!isDuplication && e.target.value !== '') {
         this.registrationLists.push({
           id: e.target.value,
           name: e.target.selectedOptions[0].text,
@@ -81,7 +81,8 @@ export default {
           name: oldEmployee.last_name + oldEmployee.first_name
         })
 
-        this.registrationIds.push(String(oldEmployee.id))
+        this.registrationIds.push(oldEmployee.id)
+        // this.registrationIds.push(String(oldEmployee.id))
       })
     }
   }

--- a/src/resources/js/pages/TaskAssign/Create.vue
+++ b/src/resources/js/pages/TaskAssign/Create.vue
@@ -30,13 +30,10 @@
               <WorkplaceInTaskAssign :workplace="workplace" />
               <div class="md:w-4/5 mx-auto p-2">
                 <label for="employeeIds" class="leading-7 text-sm text-gray-600 dark:text-gray-400">担当者</label>
-                <ValidationProvider name="担当者" rules="required" v-slot="{ errors }">
                   <Employee :employees="employees" @receiveEmployeeIds="setEmployeeIds" />
-                  <div v-if="errors" class="text-red-500 dark:text-white text-sm">{{ errors[0] }}</div>
-                  <!-- <div v-if="serverValidationMessage.errors?.employee_ids !== undefined" class="text-red-500 dark:text-white text-sm">
+                  <div v-if="serverValidationMessage.errors?.employee_ids !== undefined" class="text-red-500 dark:text-white text-sm">
                     {{ serverValidationMessage.errors.employee_ids[0] }}
-                  </div> -->
-                </ValidationProvider>
+                  </div>
               </div>
               <div class="md:w-4/5 mx-auto p-2">
                 <label for="implementation_date" class="leading-7 text-sm text-gray-600 dark:text-gray-400">実施日</label>

--- a/src/resources/js/pages/TaskAssign/Edit.vue
+++ b/src/resources/js/pages/TaskAssign/Edit.vue
@@ -31,13 +31,10 @@
               <WorkplaceInTaskAssign :workplace="workplace" />
               <div class="md:w-4/5 mx-auto p-2">
                 <label for="employeeIds" class="leading-7 text-sm text-gray-600 dark:text-gray-400">担当者</label>
-                <ValidationProvider name="担当者" rules="required" v-slot="{ errors }">
-                    <Employee :employees="employees" :oldEmployees="taskAssign.employees" @receiveEmployeeIds="setEmployeeIds"></Employee>
-                  <div v-if="errors" class="text-red-500 dark:text-white text-sm">{{ errors[0] }}</div>
-                  <!-- <div v-if="serverValidationMessage.errors?.employee_ids !== undefined" class="text-red-500 dark:text-white text-sm">
+                  <Employee :employees="employees" :oldEmployees="taskAssign.employees" @receiveEmployeeIds="setEmployeeIds"></Employee>
+                  <div v-if="serverValidationMessage.errors?.employee_ids !== undefined" class="text-red-500 dark:text-white text-sm">
                     {{ serverValidationMessage.errors.employee_ids[0] }}
-                  </div> -->
-                </ValidationProvider>
+                  </div>
               </div>
 
               <div class="md:w-4/5 mx-auto p-2">
@@ -96,7 +93,11 @@ export default {
   },
   data() {
     return {
-      taskAssign: {},
+      taskAssign: {
+        workplace_id: null,
+        employee_ids: [],
+        implementation_date: null,
+      },
       clientsWithWorkplaces: {},
       employees: [],
       workplace: {},


### PR DESCRIPTION
「作業登録」と「作業編集」で担当者が1つも指定されていない場合、以下の動作となるように変更。

①フロント側(vee-validate)のエラーは出力しない。

　＜出力しない理由＞
当該箇所ではvee-validateのカスタムルールを実装しないと実現不可であるが、
採用しているversion3系ではカスタムルールに対応していないため。

②サーバー側(Laravel)側でエラーの文字列「担当者は必ず指定してください。」のJSONを返す。
